### PR TITLE
Check for a humanoid body base

### DIFF
--- a/vanilla_procedural/scripts/generators/creatures/shared_info.lua
+++ b/vanilla_procedural/scripts/generators/creatures/shared_info.lua
@@ -2652,7 +2652,7 @@ function build_body_from_rcp(rcp,lines,options)
         //beak
         //four tentacles in place of arms]]
                 
-    if options.humanoid_only or (rcp.humanoidable and one_in(20)) then
+    if body_base ~= "HUMANOID" and (options.humanoid_only or (rcp.humanoidable and one_in(20))) then
         body_base="HUMANOID"
         options.btc="MAKE_HUMANOID"
     end


### PR DESCRIPTION
This is a change to shared_info to fix the issue of a "humanoid twisted into humanoid form". To fix this, only creatures whose body base is not already humanoid will be eligible to receive the tweak.

#1